### PR TITLE
alias succeeded? to success?

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ Metrics/LineLength:
 
 Documentation:
   Enabled: false
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ end
 result = Add.call(a: 35, b: 7)
 result.outcome # => :ok
 result.value # => 42
-result.success? # => true
+result.succeeded? # => true
+result.success? # alias for succeeded? => true
 result.failed? # => false
 
 outcome, value = Add.call(a: 35, b: 7)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ end
 result = Add.call(a: 35, b: 7)
 result.outcome # => :ok
 result.value # => 42
-result.succeeded? # => true
+result.success? # => true
 result.failed? # => false
 
 outcome, value = Add.call(a: 35, b: 7)

--- a/lib/verbalize/result.rb
+++ b/lib/verbalize/result.rb
@@ -7,6 +7,7 @@ module Verbalize
     def succeeded?
       !failed?
     end
+    alias_method :success?, :succeeded?
 
     def failed?
       outcome == :error

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -15,6 +15,20 @@ describe Verbalize::Result do
     end
   end
 
+  describe '#success?' do
+    it 'is true when the outcome is not :error' do
+      result = described_class.new(outcome: :not_error, value: nil)
+
+      expect(result).to be_success
+    end
+
+    it 'is false when the outcome is :error' do
+      result = described_class.new(outcome: :error, value: nil)
+
+      expect(result).not_to be_success
+    end
+  end
+
   describe '#failed?' do
     it 'is false when the outcome is not :error' do
       result = described_class.new(outcome: :not_error, value: nil)


### PR DESCRIPTION
`success?` is a commonly used method name/pattern for a variety of gems and use cases.  `succeeded?` is non-standard and more letters.  Provide an alias to the former and update the readme to prefer it over the old name.