### PR TITLE
Do not subclass array.  Define to_ary instead

### DIFF
--- a/lib/verbalize.rb
+++ b/lib/verbalize.rb
@@ -73,7 +73,7 @@ module Verbalize
     def call!
       new.send(:call)
     rescue UncaughtThrowError => uncaught_throw_error
-      fail_value = uncaught_throw_error.value.last
+      fail_value = uncaught_throw_error.value.value
       error = VerbalizeError.new("Unhandled fail! called with: #{fail_value.inspect}.")
       error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
       raise error

--- a/lib/verbalize/build_dangerous_action_method.rb
+++ b/lib/verbalize/build_dangerous_action_method.rb
@@ -12,7 +12,7 @@ module Verbalize
       <<-BODY.chomp
   new(#{initialize_keywords_and_values}).send(:#{method_name})
 rescue UncaughtThrowError => uncaught_throw_error
-  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.last.inspect}.")
+  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.value.inspect}.")
   error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
   raise error
       BODY

--- a/lib/verbalize/result.rb
+++ b/lib/verbalize/result.rb
@@ -1,8 +1,11 @@
 module Verbalize
-  class Result < Array
+  class Result
     def initialize(outcome:, value:)
-      super([outcome, value])
+      @outcome = outcome
+      @value   = value
     end
+
+    attr_reader :outcome, :value
 
     def succeeded?
       !failed?
@@ -12,12 +15,8 @@ module Verbalize
       outcome == :error
     end
 
-    def outcome
-      first
-    end
-
-    def value
-      last
+    def to_ary
+      [outcome, value]
     end
   end
 end

--- a/spec/build_dangerous_action_method_spec.rb
+++ b/spec/build_dangerous_action_method_spec.rb
@@ -9,7 +9,7 @@ describe Verbalize::BuildDangerousActionMethod do
 def self.call!()
   new().send(:call)
 rescue UncaughtThrowError => uncaught_throw_error
-  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.last.inspect}.")
+  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.value.inspect}.")
   error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
   raise error
 end
@@ -23,7 +23,7 @@ end
 def self.some_action!()
   new().send(:some_action)
 rescue UncaughtThrowError => uncaught_throw_error
-  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.last.inspect}.")
+  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.value.inspect}.")
   error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
   raise error
 end
@@ -37,7 +37,7 @@ end
 def self.call!(some_required_keyword:)
   new(some_required_keyword: some_required_keyword).send(:call)
 rescue UncaughtThrowError => uncaught_throw_error
-  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.last.inspect}.")
+  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.value.inspect}.")
   error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
   raise error
 end
@@ -51,7 +51,7 @@ end
 def self.call!(some_optional_keyword: nil)
   new(some_optional_keyword: some_optional_keyword).send(:call)
 rescue UncaughtThrowError => uncaught_throw_error
-  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.last.inspect}.")
+  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.value.inspect}.")
   error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
   raise error
 end
@@ -67,7 +67,7 @@ end
 def self.call!(some_required_keyword_1:, some_required_keyword_2:)
   new(some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2).send(:call)
 rescue UncaughtThrowError => uncaught_throw_error
-  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.last.inspect}.")
+  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.value.inspect}.")
   error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
   raise error
 end
@@ -83,7 +83,7 @@ end
 def self.call!(some_optional_keyword_1: nil, some_optional_keyword_2: nil)
   new(some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2).send(:call)
 rescue UncaughtThrowError => uncaught_throw_error
-  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.last.inspect}.")
+  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.value.inspect}.")
   error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
   raise error
 end
@@ -100,7 +100,7 @@ end
 def self.call!(some_required_keyword_1:, some_required_keyword_2:, some_optional_keyword_1: nil, some_optional_keyword_2: nil)
   new(some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2, some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2).send(:call)
 rescue UncaughtThrowError => uncaught_throw_error
-  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.last.inspect}.")
+  error = VerbalizeError.new("Unhandled fail! called with: \#{uncaught_throw_error.value.value.inspect}.")
   error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
   raise error
 end

--- a/spec/integration/verbalize_spec.rb
+++ b/spec/integration/verbalize_spec.rb
@@ -147,7 +147,10 @@ describe Verbalize do
         end
       end
 
-      expect(some_outer_class.call).to eql([:error, :some_failure_message])
+      outcome, value = some_outer_class.call
+
+      expect(outcome).to eq :error
+      expect(value).to   eq :some_failure_message
     end
 
     it 'fails up multiple levels' do
@@ -175,7 +178,10 @@ describe Verbalize do
         end
       end
 
-      expect(some_outer_class.call).to eql([:error, :some_failure_message])
+      outcome, value = some_outer_class.call
+
+      expect(outcome).to eq :error
+      expect(value).to   eq :some_failure_message
     end
 
     it 'raises an error with a helpful message \
@@ -231,7 +237,10 @@ describe Verbalize do
         end
       end
 
-      expect(some_outer_class.call(a: 1, b: 0)).to eql([:error, :some_failure_message])
+      outcome, value = some_outer_class.call(a: 1, b: 0)
+
+      expect(outcome).to eq :error
+      expect(value).to   eq :some_failure_message
     end
   end
 end

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -44,4 +44,21 @@ describe Verbalize::Result do
       expect(result.value).to eql(:some_value)
     end
   end
+
+  describe '#to_ary' do
+    it 'returns an array containing the outcome and value' do
+      instance = described_class.new(outcome: :not_error, value: 'foo')
+
+      expect(instance.to_ary).to eq [:not_error, 'foo']
+    end
+
+    it 'allows multiple assignment' do
+      instance = described_class.new(outcome: :not_error, value: 'foo')
+
+      outcome, value = instance
+
+      expect(outcome).to eq :not_error
+      expect(value).to eq 'foo'
+    end
+  end
 end


### PR DESCRIPTION
It is generally considered bad practice to subclass Array.  Defining `to_ary` on the result object enables the desired multi-assignment functionality, with the downside being that we can no longer assert equality of the result object directly against an array, as you will note in the changes to existing tests.