### PR TITLE
add failure? alias for failed?

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ result.value # => 42
 result.succeeded? # => true
 result.success? # alias for succeeded? => true
 result.failed? # => false
+result.failure? # alias for failed? => false
 
 outcome, value = Add.call(a: 35, b: 7)
 outcome # => :ok

--- a/lib/verbalize/result.rb
+++ b/lib/verbalize/result.rb
@@ -15,6 +15,7 @@ module Verbalize
     def failed?
       outcome == :error
     end
+    alias_method :failure?, :failed?
 
     def to_ary
       [outcome, value]

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -43,6 +43,20 @@ describe Verbalize::Result do
     end
   end
 
+  describe '#failure?' do
+    it 'is false when the outcome is not :error' do
+      result = described_class.new(outcome: :not_error, value: nil)
+
+      expect(result).not_to be_failure
+    end
+
+    it 'is true when the outcome is :error' do
+      result = described_class.new(outcome: :error, value: nil)
+
+      expect(result).to be_failure
+    end
+  end
+
   describe '#outcome' do
     it 'is simply the outcome' do
       result = described_class.new(outcome: :some_outcome, value: nil)


### PR DESCRIPTION
Alias `Result#failed?` to `Result#failure?` to make transition from Interactor to Verbalize easier.