### PR TITLE
Add Success and Failure result classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,6 @@ end
 
 #### Stubbing `call!`
 
-TODO: This needs work. If `call!` throws and the throw is not caught by another interactor, then the
-failed interactor will raise a `VerbalizeError`, not an `UncaughtThrowError`; however, if we raise a 
-`VerbalizeError` instead of throwing, then if the interactor is nested inside another interactor which would catch
-the `throw`, it will fail to catch the `VerbalizeError`.
-
 When an object calls a Verbalize interactor via `call!`, you can stub the response for the positive case with the value
 you expect to be returned.  When stubbing the negative case, you should instead throw `Verbalize::THROWN_SYMBOL`
 (and the error message, if desired):

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ class MyInteractor
   input :a
   
   def call
-    fail!('`a` must be less than 100!') if a >= 100
+    fail!('#{a} is greater than than 100!') if a >= 100
     a + 1
   end
 end
@@ -189,7 +189,7 @@ class MyInteractor
   input :a
   
   def call
-    fail!('${a} is not less than 100!') if a >= 100
+    fail!('#{a} is greater than 100!') if a >= 100
     a + 1
   end
 end
@@ -199,7 +199,7 @@ it 'fails when the input is out of bounds' do
   result = MyInteractor.call(a: 1000)
   
   expect(result).to be_failed
-  expect(result.value).to eq '1000 is not less than 100!'
+  expect(result.value).to eq '1000 is greater than 100!'
 end
 ```
 
@@ -216,31 +216,40 @@ When an object calls a Verbalize interactor via `call`, you can stub the respons
 Example:
 
 ```ruby
+class Foo
+  def do_something
+    result = MyInteractor.call(a: 1)
+    raise 'I couldn\'t do the thing!' if result.failure?
+    
+    'baz'
+  end
+end
+
 # rspec:
 describe Foo do
   describe '#something' do
     subject { described_class.new(foo: 'bar') }
     
-    it 'does the thing' do
+    it 'does the thing when my interactor succeeds' do
       successful_result = Verbalize::Success.new(123)
       allow(MyInteractor).to receive(:call)
                                .with(a: 1)
                                .and_return(successful_result)
       
-      result = described_class.something
+      result = described_class.do_something
       
       expect(result).to eq 'baz'
     end
     
-    it 'returns an error when MyInteractor fails' do
+    it 'raises an error when MyInteractor fails' do
       failed_result = Verbalize::Failure.new('Y U NO!')
       allow(MyInteractor).to receive(:call)
                                .with(a: 3)
                                .and_return(failed_result)
       
       expect {
-        described_class.something
-      }.to raise_error(FooError, 'I couldnt do the thing!')
+        described_class.do_something
+      }.to raise_error(StandardError, 'I couldnt do the thing!')
     end
   end
 end

--- a/lib/verbalize.rb
+++ b/lib/verbalize.rb
@@ -3,7 +3,8 @@ require 'verbalize/build_initialize_method'
 require 'verbalize/build_safe_action_method'
 require 'verbalize/build_dangerous_action_method'
 require 'verbalize/build_attribute_readers'
-require 'verbalize/result'
+require 'verbalize/success'
+require 'verbalize/failure'
 
 module Verbalize
   THROWN_SYMBOL = :verbalize_error
@@ -72,14 +73,12 @@ module Verbalize
     private
 
     def __verbalized_send(method_name, *args)
-      outcome = :error
-      value = catch(:verbalize_error) do
+      error = catch(:verbalize_error) do
         value = new(*args).send(method_name)
-        # The outcome is :ok if the call didn't throw.
-        outcome = :ok
-        value
+        return Success.new(value)
       end
-      Result.new(outcome: outcome, value: value)
+
+      Failure.new(error)
     end
 
     def __verbalized_send!(method_name, *args)

--- a/lib/verbalize/failure.rb
+++ b/lib/verbalize/failure.rb
@@ -8,7 +8,14 @@ module Verbalize
       super(outcome: :error, value: error)
     end
 
-    def error
+    def failure
+      @value
+    end
+
+    def value
+      warn Kernel.caller.first + ': `Verbalize::Failure#value` is deprecated; use `Verbalize::Failure#failure` '\
+        'instead when explicitly handling failures. `Verbalize::Failure#value` will raise an exception in Verbalize '\
+        '2.0 to prevent accidental use of `#value` on failure results without explicit error handling. '
       @value
     end
   end

--- a/lib/verbalize/failure.rb
+++ b/lib/verbalize/failure.rb
@@ -1,0 +1,20 @@
+require_relative 'result'
+
+module Verbalize
+  class Failure < Result
+    extend Gem::Deprecate
+
+    def initialize(error)
+      super(outcome: :error, value: error)
+    end
+
+    def error
+      @value
+    end
+
+    def value
+      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` instead for failed results.  It will be removed in Verbalize version 2.0'
+      @value
+    end
+  end
+end

--- a/lib/verbalize/failure.rb
+++ b/lib/verbalize/failure.rb
@@ -4,8 +4,8 @@ module Verbalize
   class Failure < Result
     extend Gem::Deprecate
 
-    def initialize(error)
-      super(outcome: :error, value: error)
+    def initialize(failure)
+      super(outcome: :error, value: failure)
     end
 
     def failure

--- a/lib/verbalize/failure.rb
+++ b/lib/verbalize/failure.rb
@@ -2,14 +2,8 @@ require_relative 'result'
 
 module Verbalize
   class Failure < Result
-    extend Gem::Deprecate
-
     def initialize(error)
       super(outcome: :error, value: error)
-    end
-
-    def error
-      @value
     end
   end
 end

--- a/lib/verbalize/failure.rb
+++ b/lib/verbalize/failure.rb
@@ -2,8 +2,14 @@ require_relative 'result'
 
 module Verbalize
   class Failure < Result
+    extend Gem::Deprecate
+
     def initialize(error)
       super(outcome: :error, value: error)
+    end
+
+    def error
+      @value
     end
   end
 end

--- a/lib/verbalize/failure.rb
+++ b/lib/verbalize/failure.rb
@@ -11,10 +11,5 @@ module Verbalize
     def error
       @value
     end
-
-    def value
-      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` instead for failed results.  It will be removed in Verbalize version 2.0'
-      @value
-    end
   end
 end

--- a/lib/verbalize/result.rb
+++ b/lib/verbalize/result.rb
@@ -22,8 +22,8 @@ module Verbalize
     end
 
     def value
-      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or ' \
-        '`Verbalize::Success#value` instead.  It will be removed from `Verbalize::Result` in Verbalize version 2.0'
+      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated and will be removed in Verbalize 2.0. '\
+        'Use `Verbalize::Failure#error` or `Verbalize::Success#value` instead.'
       @value
     end
   end

--- a/lib/verbalize/result.rb
+++ b/lib/verbalize/result.rb
@@ -5,7 +5,7 @@ module Verbalize
       @value   = value
     end
 
-    attr_reader :outcome, :value
+    attr_reader :outcome
 
     def succeeded?
       !failed?
@@ -19,6 +19,12 @@ module Verbalize
 
     def to_ary
       [outcome, @value]
+    end
+
+    def value
+      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or ' \
+        '`Verbalize::Success#value` instead.  It will be removed from `Verbalize::Result` in Verbalize version 2.0'
+      @value
     end
   end
 end

--- a/lib/verbalize/result.rb
+++ b/lib/verbalize/result.rb
@@ -22,7 +22,8 @@ module Verbalize
     end
 
     def value
-      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or `Verbalize::Success#value` instead.  It will be removed from `Verbalize::Result` in Verbalize version 2.0'
+      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or ' \
+        '`Verbalize::Success#value` instead.  It will be removed from `Verbalize::Result` in Verbalize version 2.0'
       @value
     end
   end

--- a/lib/verbalize/result.rb
+++ b/lib/verbalize/result.rb
@@ -5,7 +5,7 @@ module Verbalize
       @value   = value
     end
 
-    attr_reader :outcome
+    attr_reader :outcome, :value
 
     def succeeded?
       !failed?
@@ -19,12 +19,6 @@ module Verbalize
 
     def to_ary
       [outcome, @value]
-    end
-
-    def value
-      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or ' \
-        '`Verbalize::Success#value` instead.  It will be removed from `Verbalize::Result` in Verbalize version 2.0'
-      @value
     end
   end
 end

--- a/lib/verbalize/result.rb
+++ b/lib/verbalize/result.rb
@@ -5,7 +5,7 @@ module Verbalize
       @value   = value
     end
 
-    attr_reader :outcome, :value
+    attr_reader :outcome
 
     def succeeded?
       !failed?
@@ -18,7 +18,12 @@ module Verbalize
     alias_method :failure?, :failed?
 
     def to_ary
-      [outcome, value]
+      [outcome, @value]
+    end
+
+    def value
+      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or `Verbalize::Success#value` instead.  It will be removed from `Verbalize::Result` in Verbalize version 2.0'
+      @value
     end
   end
 end

--- a/lib/verbalize/success.rb
+++ b/lib/verbalize/success.rb
@@ -1,0 +1,13 @@
+require_relative 'result'
+
+module Verbalize
+  class Success < Result
+    def initialize(value)
+      super(outcome: :ok, value: value)
+    end
+
+    def value
+      @value
+    end
+  end
+end

--- a/lib/verbalize/success.rb
+++ b/lib/verbalize/success.rb
@@ -5,7 +5,5 @@ module Verbalize
     def initialize(value)
       super(outcome: :ok, value: value)
     end
-
-    attr_reader :value
   end
 end

--- a/lib/verbalize/success.rb
+++ b/lib/verbalize/success.rb
@@ -6,8 +6,6 @@ module Verbalize
       super(outcome: :ok, value: value)
     end
 
-    def value
-      @value
-    end
+    attr_reader :value
   end
 end

--- a/lib/verbalize/success.rb
+++ b/lib/verbalize/success.rb
@@ -5,5 +5,7 @@ module Verbalize
     def initialize(value)
       super(outcome: :ok, value: value)
     end
+
+    attr_reader :value
   end
 end

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -58,11 +58,13 @@ describe Verbalize::Failure do
     end
 
     it 'emits a deprecation warning' do
-      expected_message = %r{.*failure_spec.rb:\d+:in .*: `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\.  It will be removed from `Verbalize::Result` in Verbalize version 2\.0}
+      expected_message = Regexp.compile('.*failure_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated; ' \
+                                          'use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\\.' \
+                                          '  It will be removed from `Verbalize::Result` in Verbalize version 2\\.0')
       result = described_class.new('some_error')
-      expect {
+      expect do
         result.value
-      }.to output(expected_message).to_stderr
+      end.to output(expected_message).to_stderr
     end
   end
 

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -42,11 +42,29 @@ describe Verbalize::Failure do
     end
   end
 
+  describe '#error' do
+    it 'is the error message' do
+      result = described_class.new('some_error')
+
+      expect(result.error).to eq 'some_error'
+    end
+  end
+
   describe '#value' do
     it 'is the error message' do
       result = described_class.new('some_error')
 
       expect(result.value).to eq 'some_error'
+    end
+
+    it 'emits a deprecation warning' do
+      expected_message = Regexp.compile('.*failure_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated; ' \
+                                          'use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\\.' \
+                                          '  It will be removed from `Verbalize::Result` in Verbalize version 2\\.0')
+      result = described_class.new('some_error')
+      expect do
+        result.value
+      end.to output(expected_message).to_stderr
     end
   end
 

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -42,11 +42,11 @@ describe Verbalize::Failure do
     end
   end
 
-  describe '#error' do
+  describe '#failure' do
     it 'is the error message' do
       result = described_class.new('some_error')
 
-      expect(result.error).to eq 'some_error'
+      expect(result.failure).to eq 'some_error'
     end
   end
 
@@ -58,9 +58,8 @@ describe Verbalize::Failure do
     end
 
     it 'emits a deprecation warning' do
-      expected_message = Regexp.compile('.*failure_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated; ' \
-                                          'use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\\.' \
-                                          '  It will be removed from `Verbalize::Result` in Verbalize version 2\\.0')
+      expected_message = Regexp.compile('.*failure_spec.rb:\\d+:in .*: `Verbalize::Failure#value` is deprecated; ' \
+                                          'use `Verbalize::Failure#failure` instead')
       result = described_class.new('some_error')
       expect do
         result.value

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -58,7 +58,7 @@ describe Verbalize::Failure do
     end
 
     it 'emits a deprecation warning' do
-      expected_message = %r{.*failure_spec.rb:\d+:in .*: `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` instead for failed results\.  It will be removed in Verbalize version 2\.0}
+      expected_message = %r{.*failure_spec.rb:\d+:in .*: `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\.  It will be removed from `Verbalize::Result` in Verbalize version 2\.0}
       result = described_class.new('some_error')
       expect {
         result.value

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'verbalize/failure'
+
+describe Verbalize::Failure do
+  describe '#succeeded?' do
+    it 'is false' do
+      result = described_class.new(nil)
+
+      expect(result).not_to be_succeeded
+    end
+  end
+
+  describe '#success?' do
+    it 'is false' do
+      result = described_class.new(nil)
+
+      expect(result).not_to be_success
+    end
+  end
+
+  describe '#failed?' do
+    it 'is true' do
+      result = described_class.new(nil)
+
+      expect(result).to be_failed
+    end
+  end
+
+  describe '#failure?' do
+    it 'is true' do
+      result = described_class.new(nil)
+
+      expect(result).to be_failure
+    end
+  end
+
+  describe '#outcome' do
+    it 'is :error' do
+      result = described_class.new(nil)
+
+      expect(result.outcome).to be :error
+    end
+  end
+
+  describe '#error' do
+    it 'is the error message' do
+      result = described_class.new('some_error')
+
+      expect(result.error).to eq 'some_error'
+    end
+  end
+
+  describe '#value' do
+    it 'is the error message' do
+      result = described_class.new('some_error')
+
+      expect(result.value).to eq 'some_error'
+    end
+
+    it 'emits a deprecation warning' do
+      expected_message = %r{.*failure_spec.rb:\d+:in .*: `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` instead for failed results\.  It will be removed in Verbalize version 2\.0}
+      result = described_class.new('some_error')
+      expect {
+        result.value
+      }.to output(expected_message).to_stderr
+    end
+  end
+
+  describe '#to_ary' do
+    it 'returns an array containing the outcome and value' do
+      instance = described_class.new('foo')
+
+      expect(instance.to_ary).to eq [:error, 'foo']
+    end
+
+    it 'allows multiple assignment' do
+      instance = described_class.new('foo')
+
+      outcome, value = instance
+
+      expect(outcome).to eq :error
+      expect(value).to eq 'foo'
+    end
+  end
+end

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -42,29 +42,11 @@ describe Verbalize::Failure do
     end
   end
 
-  describe '#error' do
-    it 'is the error message' do
-      result = described_class.new('some_error')
-
-      expect(result.error).to eq 'some_error'
-    end
-  end
-
   describe '#value' do
     it 'is the error message' do
       result = described_class.new('some_error')
 
       expect(result.value).to eq 'some_error'
-    end
-
-    it 'emits a deprecation warning' do
-      expected_message = Regexp.compile('.*failure_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated; ' \
-                                          'use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\\.' \
-                                          '  It will be removed from `Verbalize::Result` in Verbalize version 2\\.0')
-      result = described_class.new('some_error')
-      expect do
-        result.value
-      end.to output(expected_message).to_stderr
     end
   end
 

--- a/spec/integration/verbalize_spec.rb
+++ b/spec/integration/verbalize_spec.rb
@@ -153,9 +153,9 @@ describe Verbalize do
       end
 
       some_outer_class = Class.new(base_verbalize_class)
-      some_outer_class.class_exec(some_inner_class) do |some_inner_class|
+      some_outer_class.class_exec(some_inner_class) do |interactor_class|
         define_method(:call) do
-          some_inner_class.call!
+          interactor_class.call!
         end
       end
 
@@ -174,9 +174,9 @@ describe Verbalize do
       end
 
       some_outer_class = Class.new(base_verbalize_class)
-      some_outer_class.class_exec(some_inner_class) do |some_inner_class|
+      some_outer_class.class_exec(some_inner_class) do |interactor_class|
         define_method(:call) do
-          some_inner_class.call!
+          interactor_class.call!
         end
       end
 
@@ -197,16 +197,16 @@ describe Verbalize do
       end
 
       some_inner_class = Class.new(base_verbalize_class)
-      some_inner_class.class_exec(some_inner_inner_class) do |some_inner_inner_class|
+      some_inner_class.class_exec(some_inner_inner_class) do |interactor_class|
         define_method(:call) do
-          some_inner_inner_class.call!
+          interactor_class.call!
         end
       end
 
       some_outer_class = Class.new(base_verbalize_class)
-      some_outer_class.class_exec(some_inner_class) do |some_inner_class|
+      some_outer_class.class_exec(some_inner_class) do |interactor_class|
         define_method(:call) do
-          some_inner_class.call!
+          interactor_class.call!
         end
       end
 
@@ -254,11 +254,11 @@ describe Verbalize do
       end
 
       some_outer_class = Class.new(base_verbalize_class)
-      some_outer_class.class_exec(some_inner_class) do |some_inner_class|
+      some_outer_class.class_exec(some_inner_class) do |interactor_class|
         input :a, :b
 
         define_method(:call) do
-          some_inner_class.call!(a: a, b: b)
+          interactor_class.call!(a: a, b: b)
         end
       end
 

--- a/spec/integration/verbalize_spec.rb
+++ b/spec/integration/verbalize_spec.rb
@@ -64,8 +64,7 @@ describe Verbalize do
         some_class = Class.new(base_verbalize_class) do
           input :a, :b
 
-          def call
-          end
+          def call; end
         end
 
         expect { some_class.call(a: 42) }.to raise_error(ArgumentError)

--- a/spec/integration/verbalize_spec.rb
+++ b/spec/integration/verbalize_spec.rb
@@ -1,15 +1,11 @@
 require 'spec_helper'
 
 describe Verbalize do
-  let(:base_verbalize_class) do
-    Class.new do
-      include Verbalize
-    end
-  end
-
   describe '.verbalize' do
-    it 'returns an ErrorResult on failure' do
-      some_class = Class.new(base_verbalize_class) do
+    it 'returns a Verbalize::Failure instance on fail!' do
+      some_class = Class.new do
+        include Verbalize
+
         def call
           fail!('Some error')
         end
@@ -18,8 +14,10 @@ describe Verbalize do
       expect(some_class.call).to be_an_instance_of(Verbalize::Failure)
     end
 
-    it 'returns a SuccessResult on success' do
-      some_class = Class.new(base_verbalize_class) do
+    it 'returns a Verbalize::Success instance on success' do
+      some_class = Class.new do
+        include Verbalize
+
         def call
           true
         end
@@ -31,7 +29,9 @@ describe Verbalize do
     context 'with arguments' do
       it 'allows arguments to be defined and delegates the class method \
       to the instance method' do
-        some_class = Class.new(base_verbalize_class) do
+        some_class = Class.new do
+          include Verbalize
+
           input :a, :b
 
           def call
@@ -46,7 +46,9 @@ describe Verbalize do
       end
 
       it 'allows class & instance method to be named differently' do
-        some_class = Class.new(base_verbalize_class) do
+        some_class = Class.new do
+          include Verbalize
+
           verbalize :some_method_name
 
           def some_method_name
@@ -61,7 +63,9 @@ describe Verbalize do
       end
 
       it 'raises an error when you don’t specify a required argument' do
-        some_class = Class.new(base_verbalize_class) do
+        some_class = Class.new do
+          include Verbalize
+
           input :a, :b
 
           def call; end
@@ -71,7 +75,9 @@ describe Verbalize do
       end
 
       it 'allows you to specify an optional argument' do
-        some_class = Class.new(base_verbalize_class) do
+        some_class = Class.new do
+          include Verbalize
+
           input :a, optional: :b
 
           def call
@@ -90,7 +96,9 @@ describe Verbalize do
       end
 
       it 'allows you to fail an action and not execute remaining lines' do
-        some_class = Class.new(base_verbalize_class) do
+        some_class = Class.new do
+          include Verbalize
+
           input :a, :b
 
           def call
@@ -109,7 +117,9 @@ describe Verbalize do
 
     context 'without_arguments' do
       it 'still does something' do
-        some_class = Class.new(base_verbalize_class) do
+        some_class = Class.new do
+          include Verbalize
+
           def call
             :some_behavior
           end
@@ -122,7 +132,9 @@ describe Verbalize do
       end
 
       it 'allows you to fail an action and not execute remaining lines' do
-        some_class = Class.new(base_verbalize_class) do
+        some_class = Class.new do
+          include Verbalize
+
           def call
             fail! 'Are you crazy?!? You can’t divide by zero!'
             1 / 0
@@ -137,7 +149,9 @@ describe Verbalize do
 
       it 'raises an error if you specify unrecognized keyword/value arguments' do
         expect do
-          Class.new(base_verbalize_class) do
+          Class.new do
+            include Verbalize
+
             input improper: :usage
           end
         end.to raise_error(ArgumentError)
@@ -145,13 +159,18 @@ describe Verbalize do
     end
 
     it 'fails up to a parent action' do
-      some_inner_class = Class.new(base_verbalize_class) do
+      some_inner_class = Class.new do
+        include Verbalize
+
         def call
           fail! :some_failure_message
         end
       end
 
-      some_outer_class = Class.new(base_verbalize_class)
+      some_outer_class = Class.new do
+        include Verbalize
+      end
+
       some_outer_class.class_exec(some_inner_class) do |interactor_class|
         define_method(:call) do
           interactor_class.call!
@@ -166,13 +185,18 @@ describe Verbalize do
     end
 
     it 'stubbed failures are captured by parent actions' do
-      some_inner_class = Class.new(base_verbalize_class) do
+      some_inner_class = Class.new do
+        include Verbalize
+
         def call
           fail! :some_failure_message
         end
       end
 
-      some_outer_class = Class.new(base_verbalize_class)
+      some_outer_class = Class.new do
+        include Verbalize
+      end
+
       some_outer_class.class_exec(some_inner_class) do |interactor_class|
         define_method(:call) do
           interactor_class.call!
@@ -189,20 +213,28 @@ describe Verbalize do
     end
 
     it 'fails up multiple levels' do
-      some_inner_inner_class = Class.new(base_verbalize_class) do
+      some_inner_inner_class = Class.new do
+        include Verbalize
+
         def call
           fail! :some_failure_message
         end
       end
 
-      some_inner_class = Class.new(base_verbalize_class)
+      some_inner_class = Class.new do
+        include Verbalize
+      end
+
       some_inner_class.class_exec(some_inner_inner_class) do |interactor_class|
         define_method(:call) do
           interactor_class.call!
         end
       end
 
-      some_outer_class = Class.new(base_verbalize_class)
+      some_outer_class = Class.new do
+        include Verbalize
+      end
+
       some_outer_class.class_exec(some_inner_class) do |interactor_class|
         define_method(:call) do
           interactor_class.call!
@@ -217,7 +249,9 @@ describe Verbalize do
 
     it 'raises an error with a helpful message \
     if an action fails without being handled' do
-      some_class = Class.new(base_verbalize_class) do
+      some_class = Class.new do
+        include Verbalize
+
         def call
           fail! :some_failure_message
         end
@@ -230,7 +264,9 @@ describe Verbalize do
 
     it 'raises an error with a helpful message if an action with keywords \
     fails without being handled' do
-      some_class = Class.new(base_verbalize_class) do
+      some_class = Class.new do
+        include Verbalize
+
         input :a, :b
 
         def call
@@ -244,7 +280,9 @@ describe Verbalize do
     end
 
     it 'fails up to a parent action with keywords' do
-      some_inner_class = Class.new(base_verbalize_class) do
+      some_inner_class = Class.new do
+        include Verbalize
+
         input :a, :b
 
         def call
@@ -252,7 +290,10 @@ describe Verbalize do
         end
       end
 
-      some_outer_class = Class.new(base_verbalize_class)
+      some_outer_class = Class.new do
+        include Verbalize
+      end
+
       some_outer_class.class_exec(some_inner_class) do |interactor_class|
         input :a, :b
 

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -71,6 +71,14 @@ describe Verbalize::Result do
 
       expect(result.value).to eql(:some_value)
     end
+
+    it 'emits a deprecation warning' do
+      expected_message = %r{.*result_spec.rb:\d+:in .*: `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\.  It will be removed from `Verbalize::Result` in Verbalize version 2\.0}
+      result = described_class.new(outcome: nil, value: :some_value)
+      expect {
+        result.value
+      }.to output(expected_message).to_stderr
+    end
   end
 
   describe '#to_ary' do

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -71,16 +71,6 @@ describe Verbalize::Result do
 
       expect(result.value).to eql(:some_value)
     end
-
-    it 'emits a deprecation warning' do
-      expected_message = Regexp.compile('.*result_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated; ' \
-                                          'use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\\.' \
-                                          '  It will be removed from `Verbalize::Result` in Verbalize version 2\\.0')
-      result = described_class.new(outcome: nil, value: :some_value)
-      expect do
-        result.value
-      end.to output(expected_message).to_stderr
-    end
   end
 
   describe '#to_ary' do

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -73,11 +73,13 @@ describe Verbalize::Result do
     end
 
     it 'emits a deprecation warning' do
-      expected_message = %r{.*result_spec.rb:\d+:in .*: `Verbalize::Result#value` is deprecated; use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\.  It will be removed from `Verbalize::Result` in Verbalize version 2\.0}
+      expected_message = Regexp.compile('.*result_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated; ' \
+                                          'use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\\.' \
+                                          '  It will be removed from `Verbalize::Result` in Verbalize version 2\\.0')
       result = described_class.new(outcome: nil, value: :some_value)
-      expect {
+      expect do
         result.value
-      }.to output(expected_message).to_stderr
+      end.to output(expected_message).to_stderr
     end
   end
 

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -73,9 +73,9 @@ describe Verbalize::Result do
     end
 
     it 'emits a deprecation warning' do
-      expected_message = Regexp.compile('.*result_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated; ' \
-                                          'use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\\.' \
-                                          '  It will be removed from `Verbalize::Result` in Verbalize version 2\\.0')
+      expected_message = Regexp.compile('.*result_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated ' \
+                                          'and will be removed in Verbalize 2\\.0\\. Use `Verbalize::Failure#error` ' \
+                                          'or `Verbalize::Success#value` instead\\.')
       result = described_class.new(outcome: nil, value: :some_value)
       expect do
         result.value

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -71,6 +71,16 @@ describe Verbalize::Result do
 
       expect(result.value).to eql(:some_value)
     end
+
+    it 'emits a deprecation warning' do
+      expected_message = Regexp.compile('.*result_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated; ' \
+                                          'use `Verbalize::Failure#error` or `Verbalize::Success#value` instead\\.' \
+                                          '  It will be removed from `Verbalize::Result` in Verbalize version 2\\.0')
+      result = described_class.new(outcome: nil, value: :some_value)
+      expect do
+        result.value
+      end.to output(expected_message).to_stderr
+    end
   end
 
   describe '#to_ary' do

--- a/spec/success_spec.rb
+++ b/spec/success_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'verbalize/success'
+
+describe Verbalize::Success do
+  describe '#succeeded?' do
+    it 'is true' do
+      result = described_class.new(nil)
+
+      expect(result).to be_succeeded
+    end
+  end
+
+  describe '#success?' do
+    it 'is true' do
+      result = described_class.new(nil)
+
+      expect(result).to be_success
+    end
+  end
+
+  describe '#failed?' do
+    it 'is false' do
+      result = described_class.new(nil)
+
+      expect(result).not_to be_failed
+    end
+  end
+
+  describe '#failure?' do
+    it 'is false' do
+      result = described_class.new(nil)
+
+      expect(result).not_to be_failure
+    end
+  end
+
+  describe '#outcome' do
+    it 'is :ok' do
+      result = described_class.new(nil)
+
+      expect(result.outcome).to be :ok
+    end
+  end
+
+  describe '#value' do
+    it 'is simply the value' do
+      result = described_class.new('some_value')
+
+      expect(result.value).to eq 'some_value'
+    end
+  end
+
+  describe '#to_ary' do
+    it 'returns an array containing the outcome and value' do
+      instance = described_class.new('foo')
+
+      expect(instance.to_ary).to eq [:ok, 'foo']
+    end
+
+    it 'allows multiple assignment' do
+      instance = described_class.new('foo')
+
+      outcome, value = instance
+
+      expect(outcome).to eq :ok
+      expect(value).to eq 'foo'
+    end
+  end
+end


### PR DESCRIPTION
@taylorzr This adds Success and Failure result classes which make Verbalize easier to work with when testing interactors in consumers.  There is no longer any need to know anything about the internals of the Result class to produce a failed result; rather, in test you can now just create `Verbalize::Success` or `Verbalize::Failure` instances.

Also, I added `Failure#error` and deprecated the generic `Result#value` method, which is unnatural to reference when working with a failed result.

 - Deprecate Result#value and Failure#value in favor of Success#value and Failure#error
 - Refactor verbalize_spec to eliminate constant redefined warnings