### PR TITLE
Deprecate custom methods

### DIFF
--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -31,11 +31,7 @@ module Verbalize
         **other_keyword_arguments
       )
 
-        if method_name != :call
-          warn Kernel.caller[1] + ': use of custom method names for Actions is deprecated and support ' \
-            'for it will be dropped in Verbalize v2.0.  The `verbalize` method will also be removed.' \
-            'Use `input` and define `#call` on your Action class instead.'
-        end
+        deprecate_custom_methods(method_name)
 
         unless other_keyword_arguments.empty?
           raise(
@@ -77,6 +73,13 @@ module Verbalize
       end
 
       private
+
+      def deprecate_custom_methods(method_name)
+        return if method_name == :call
+        warn Kernel.caller[2] + ': use of custom method names for Actions is deprecated and support ' \
+          'for it will be dropped in Verbalize v2.0.  The `verbalize` method will also be removed.' \
+          'Use `input` and define `#call` on your Action class instead.'
+      end
 
       def __verbalized_send(method_name, *args)
         error = catch(:verbalize_error) do

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -31,6 +31,12 @@ module Verbalize
         **other_keyword_arguments
       )
 
+        if method_name != :call
+          warn Kernel.caller[1] + ': use of custom method names for Actions is deprecated and support ' \
+            'for it will be dropped in Verbalize v2.0.  The `verbalize` method will also be removed.' \
+            'Use `input` and define `#call` on your Action class instead.'
+        end
+
         unless other_keyword_arguments.empty?
           raise(
             ArgumentError,

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -54,7 +54,7 @@ describe Verbalize::Failure do
     it 'is the error message' do
       result = described_class.new('some_error')
 
-      expect(result.value).to eq 'some_error'
+      expect(result.failure).to eq 'some_error'
     end
 
     it 'emits a deprecation warning' do

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -66,7 +66,7 @@ describe Verbalize::Action do
         expected_message = Regexp.compile('action_spec.rb:\d+.*use of custom method names for Actions is ' \
                                           'deprecated.* define `#call` on your Action class instead')
         expect do
-          some_class = Class.new do
+          Class.new do
             include Verbalize::Action
 
             verbalize :some_method_name

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -62,6 +62,18 @@ describe Verbalize::Action do
         expect(result.value).to eql(:some_method_result)
       end
 
+      it 'using custom method name emits a deprecation warning' do
+        expected_message = Regexp.compile('action_spec.rb:\d+.*use of custom method names for Actions is ' \
+                                          'deprecated.* define `#call` on your Action class instead')
+        expect do
+          some_class = Class.new do
+            include Verbalize::Action
+
+            verbalize :some_method_name
+          end
+        end.to output(expected_message).to_stderr
+      end
+
       it 'raises an error when you don’t specify a required argument' do
         some_class = Class.new do
           include Verbalize::Action
@@ -111,7 +123,7 @@ describe Verbalize::Action do
 
         expect(result).not_to be_success
         expect(result).to be_failed
-        expect(result.value).to eql('Are you crazy?!? You can’t divide by zero!')
+        expect(result.failure).to eql('Are you crazy?!? You can’t divide by zero!')
       end
     end
 
@@ -144,7 +156,7 @@ describe Verbalize::Action do
         result = some_class.call
 
         expect(result).to be_failed
-        expect(result.value).to eql('Are you crazy?!? You can’t divide by zero!')
+        expect(result.failure).to eql('Are you crazy?!? You can’t divide by zero!')
       end
 
       it 'raises an error if you specify unrecognized keyword/value arguments' do
@@ -181,7 +193,7 @@ describe Verbalize::Action do
 
       expect(result).not_to   be_success
       expect(result).to       be_failed
-      expect(result.value).to eq :some_failure_message
+      expect(result.failure).to eq :some_failure_message
     end
 
     it 'stubbed failures are captured by parent actions' do
@@ -209,7 +221,7 @@ describe Verbalize::Action do
 
       expect(result).not_to   be_success
       expect(result).to       be_failed
-      expect(result.value).to eq 'foo error'
+      expect(result.failure).to eq 'foo error'
     end
 
     it 'fails up multiple levels' do


### PR DESCRIPTION
This deprecates custom methods in favor of standardizing on `call` and `call!`, per our discussion yesterday.  It is based on top of #9 and should be reviewed/merged after that PR.