### PR TITLE
Version 2 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ end
 ### Sad Path
 
 When testing negative cases of a `Verbalize::Action`, it is recommended to test using the `call` non-bang 
-class method.  Use of `call!` here is not advised as it will result in an exception being thrown. Set assertions 
-on both the outcome and error value of the result:
+class method which will return a `Verbalize::Failure` on failure.
+
+Use of `call!` here is not advised as it will result in an exception being thrown. Set assertions on both 
+the failure outcome and value:
 
 ```ruby
 class MyAction
@@ -199,7 +201,7 @@ it 'fails when the input is out of bounds' do
   result = MyAction.call(a: 1000)
   
   expect(result).to be_failed
-  expect(result.value).to eq '1000 is greater than 100!'
+  expect(result.failure).to eq '1000 is greater than 100!'
 end
 ```
 

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -19,20 +19,11 @@ module Verbalize
     end
 
     module ClassMethods
-      def verbalize(*arguments, **keyword_arguments)
-        method_name, *arguments = arguments
-        input(*arguments, method_name: method_name, **keyword_arguments)
-      end
-
       def input( # rubocop:disable Metrics/MethodLength
         *required_keywords,
         optional:    [],
-        method_name: :call,
         **other_keyword_arguments
       )
-
-        deprecate_custom_methods(method_name)
-
         unless other_keyword_arguments.empty?
           raise(
             ArgumentError,
@@ -44,14 +35,12 @@ module Verbalize
 
         class_eval BuildSafeActionMethod.call(
           required_keywords: required_keywords,
-          optional_keywords: optional_keywords,
-          method_name:       method_name
+          optional_keywords: optional_keywords
         )
 
         class_eval BuildDangerousActionMethod.call(
           required_keywords: required_keywords,
-          optional_keywords: optional_keywords,
-          method_name:       method_name
+          optional_keywords: optional_keywords
         )
 
         class_eval BuildInitializeMethod.call(

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -83,7 +83,7 @@ module Verbalize
         new(*args).send(method_name)
       rescue UncaughtThrowError => uncaught_throw_error
         fail_value = uncaught_throw_error.value
-        error = VerbalizeError.new("Unhandled fail! called with: #{fail_value.inspect}.")
+        error = Verbalize::Error.new("Unhandled fail! called with: #{fail_value.inspect}.")
         error.set_backtrace(uncaught_throw_error.backtrace[2..-1])
         raise error
       end

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -54,26 +54,30 @@ module Verbalize
       end
 
       def call
-        __verbalized_send(:call)
+        __verbalized_send
       end
 
       def call!
-        __verbalized_send!(:call)
+        __verbalized_send!
       end
 
       private
 
-      def __verbalized_send(method_name, *args)
+      def perform(*args)
+        new(*args).send(:call)
+      end
+
+      def __verbalized_send(*args)
         error = catch(:verbalize_error) do
-          value = new(*args).send(method_name)
+          value = perform(*args)
           return Success.new(value)
         end
 
         Failure.new(error)
       end
 
-      def __verbalized_send!(method_name, *args)
-        new(*args).send(method_name)
+      def __verbalized_send!(*args)
+        perform(*args)
       rescue UncaughtThrowError => uncaught_throw_error
         fail_value = uncaught_throw_error.value
         error = Verbalize::Error.new("Unhandled fail! called with: #{fail_value.inspect}.")

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -63,13 +63,6 @@ module Verbalize
 
       private
 
-      def deprecate_custom_methods(method_name)
-        return if method_name == :call
-        warn Kernel.caller[2] + ': use of custom method names for Actions is deprecated and support ' \
-          'for it will be dropped in Verbalize v2.0.  The `verbalize` method will also be removed.' \
-          'Use `input` and define `#call` on your Action class instead.'
-      end
-
       def __verbalized_send(method_name, *args)
         error = catch(:verbalize_error) do
           value = new(*args).send(method_name)

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -21,7 +21,7 @@ module Verbalize
     module ClassMethods
       def input( # rubocop:disable Metrics/MethodLength
         *required_keywords,
-        optional:    [],
+        optional: [],
         **other_keyword_arguments
       )
         unless other_keyword_arguments.empty?

--- a/lib/verbalize/build_dangerous_action_method.rb
+++ b/lib/verbalize/build_dangerous_action_method.rb
@@ -5,14 +5,14 @@ module Verbalize
     private
 
     def declaration
-      "def self.#{method_name}!(#{declaration_keyword_arguments})"
+      "def self.call!(#{declaration_keyword_arguments})"
     end
 
     def body
       if all_keywords.empty?
-        "  __verbalized_send!(:#{method_name})"
+        "  __verbalized_send!(:call)"
       else
-        "  __verbalized_send!(:#{method_name}, #{initialize_keywords_and_values})"
+        "  __verbalized_send!(:call, #{initialize_keywords_and_values})"
       end
     end
   end

--- a/lib/verbalize/build_dangerous_action_method.rb
+++ b/lib/verbalize/build_dangerous_action_method.rb
@@ -5,7 +5,7 @@ module Verbalize
     private
 
     def declaration
-      "def self.call!(#{declaration_keyword_arguments})"
+      declare('self.call!')
     end
 
     def body

--- a/lib/verbalize/build_dangerous_action_method.rb
+++ b/lib/verbalize/build_dangerous_action_method.rb
@@ -10,9 +10,9 @@ module Verbalize
 
     def body
       if all_keywords.empty?
-        '  __verbalized_send!(:call)'
+        '  __verbalized_send!'
       else
-        "  __verbalized_send!(:call, #{initialize_keywords_and_values})"
+        "  __verbalized_send!(#{initialize_keywords_and_values})"
       end
     end
   end

--- a/lib/verbalize/build_dangerous_action_method.rb
+++ b/lib/verbalize/build_dangerous_action_method.rb
@@ -9,11 +9,7 @@ module Verbalize
     end
 
     def body
-      if all_keywords.empty?
-        '  __verbalized_send!'
-      else
-        "  __verbalized_send!(#{initialize_keywords_and_values})"
-      end
+      verbalized_send_string(bang: true)
     end
   end
 end

--- a/lib/verbalize/build_dangerous_action_method.rb
+++ b/lib/verbalize/build_dangerous_action_method.rb
@@ -10,7 +10,7 @@ module Verbalize
 
     def body
       if all_keywords.empty?
-        "  __verbalized_send!(:call)"
+        '  __verbalized_send!(:call)'
       else
         "  __verbalized_send!(:call, #{initialize_keywords_and_values})"
       end

--- a/lib/verbalize/build_initialize_method.rb
+++ b/lib/verbalize/build_initialize_method.rb
@@ -5,7 +5,7 @@ module Verbalize
     private
 
     def declaration
-      "def initialize(#{declaration_keyword_arguments})"
+      declare('initialize')
     end
 
     def body

--- a/lib/verbalize/build_method_base.rb
+++ b/lib/verbalize/build_method_base.rb
@@ -32,6 +32,10 @@ module Verbalize
       raise NotImplementedError
     end
 
+    def declare(method_name)
+      "def #{method_name}(#{declaration_keyword_arguments})"
+    end
+
     def all_keywords
       required_keywords + optional_keywords
     end

--- a/lib/verbalize/build_method_base.rb
+++ b/lib/verbalize/build_method_base.rb
@@ -1,16 +1,14 @@
 class BuildMethodBase
-  def self.call(required_keywords: [], optional_keywords: [], method_name: :call)
+  def self.call(required_keywords: [], optional_keywords: [])
     new(
       required_keywords: required_keywords,
-      optional_keywords: optional_keywords,
-      method_name:       method_name
+      optional_keywords: optional_keywords
     ).call
   end
 
-  def initialize(required_keywords: [], optional_keywords: [], method_name: :call)
+  def initialize(required_keywords: [], optional_keywords: [])
     @required_keywords = required_keywords
     @optional_keywords = optional_keywords
-    @method_name       = method_name
   end
 
   def call
@@ -19,7 +17,7 @@ class BuildMethodBase
 
   private
 
-  attr_reader :required_keywords, :optional_keywords, :method_name
+  attr_reader :required_keywords, :optional_keywords
 
   def parts
     [declaration, body, "end\n"]

--- a/lib/verbalize/build_method_base.rb
+++ b/lib/verbalize/build_method_base.rb
@@ -1,54 +1,56 @@
-class BuildMethodBase
-  def self.call(required_keywords: [], optional_keywords: [])
-    new(
-      required_keywords: required_keywords,
-      optional_keywords: optional_keywords
-    ).call
-  end
+module Verbalize
+  class BuildMethodBase
+    def self.call(required_keywords: [], optional_keywords: [])
+      new(
+        required_keywords: required_keywords,
+        optional_keywords: optional_keywords
+      ).call
+    end
 
-  def initialize(required_keywords: [], optional_keywords: [])
-    @required_keywords = required_keywords
-    @optional_keywords = optional_keywords
-  end
+    def initialize(required_keywords: [], optional_keywords: [])
+      @required_keywords = required_keywords
+      @optional_keywords = optional_keywords
+    end
 
-  def call
-    parts.compact.join "\n"
-  end
+    def call
+      parts.compact.join "\n"
+    end
 
-  private
+    private
 
-  attr_reader :required_keywords, :optional_keywords
+    attr_reader :required_keywords, :optional_keywords
 
-  def parts
-    [declaration, body, "end\n"]
-  end
+    def parts
+      [declaration, body, "end\n"]
+    end
 
-  def declaration
-    raise NotImplementedError
-  end
+    def declaration
+      raise NotImplementedError
+    end
 
-  def body
-    raise NotImplementedError
-  end
+    def body
+      raise NotImplementedError
+    end
 
-  def all_keywords
-    required_keywords + optional_keywords
-  end
+    def all_keywords
+      required_keywords + optional_keywords
+    end
 
-  def required_keyword_segments
-    required_keywords.map { |keyword| "#{keyword}:" }
-  end
+    def required_keyword_segments
+      required_keywords.map { |keyword| "#{keyword}:" }
+    end
 
-  def optional_keyword_segments
-    optional_keywords.map { |keyword| "#{keyword}: nil" }
-  end
+    def optional_keyword_segments
+      optional_keywords.map { |keyword| "#{keyword}: nil" }
+    end
 
-  def declaration_keyword_arguments
-    return if all_keywords.empty?
-    (required_keyword_segments + optional_keyword_segments).join(', ')
-  end
+    def declaration_keyword_arguments
+      return if all_keywords.empty?
+      (required_keyword_segments + optional_keyword_segments).join(', ')
+    end
 
-  def initialize_keywords_and_values
-    all_keywords.map { |variable| "#{variable}: #{variable}" }.join(', ')
+    def initialize_keywords_and_values
+      all_keywords.map { |variable| "#{variable}: #{variable}" }.join(', ')
+    end
   end
 end

--- a/lib/verbalize/build_method_base.rb
+++ b/lib/verbalize/build_method_base.rb
@@ -56,5 +56,13 @@ module Verbalize
     def initialize_keywords_and_values
       all_keywords.map { |variable| "#{variable}: #{variable}" }.join(', ')
     end
+
+    def verbalized_send_string(bang: false)
+      send_string = '  __verbalized_send'
+      send_string += '!' if bang
+
+      return send_string if all_keywords.empty?
+      send_string + "(#{initialize_keywords_and_values})"
+    end
   end
 end

--- a/lib/verbalize/build_safe_action_method.rb
+++ b/lib/verbalize/build_safe_action_method.rb
@@ -9,11 +9,7 @@ module Verbalize
     end
 
     def body
-      if all_keywords.empty?
-        '  __verbalized_send'
-      else
-        "  __verbalized_send(#{initialize_keywords_and_values})"
-      end
+      verbalized_send_string(bang: false)
     end
   end
 end

--- a/lib/verbalize/build_safe_action_method.rb
+++ b/lib/verbalize/build_safe_action_method.rb
@@ -10,9 +10,9 @@ module Verbalize
 
     def body
       if all_keywords.empty?
-        '  __verbalized_send(:call)'
+        '  __verbalized_send'
       else
-        "  __verbalized_send(:call, #{initialize_keywords_and_values})"
+        "  __verbalized_send(#{initialize_keywords_and_values})"
       end
     end
   end

--- a/lib/verbalize/build_safe_action_method.rb
+++ b/lib/verbalize/build_safe_action_method.rb
@@ -5,7 +5,7 @@ module Verbalize
     private
 
     def declaration
-      "def self.call(#{declaration_keyword_arguments})"
+      declare('self.call')
     end
 
     def body

--- a/lib/verbalize/build_safe_action_method.rb
+++ b/lib/verbalize/build_safe_action_method.rb
@@ -5,14 +5,14 @@ module Verbalize
     private
 
     def declaration
-      "def self.#{method_name}(#{declaration_keyword_arguments})"
+      "def self.call(#{declaration_keyword_arguments})"
     end
 
     def body
       if all_keywords.empty?
-        "  __verbalized_send(:#{method_name})"
+        "  __verbalized_send(:call)"
       else
-        "  __verbalized_send(:#{method_name}, #{initialize_keywords_and_values})"
+        "  __verbalized_send(:call, #{initialize_keywords_and_values})"
       end
     end
   end

--- a/lib/verbalize/build_safe_action_method.rb
+++ b/lib/verbalize/build_safe_action_method.rb
@@ -10,7 +10,7 @@ module Verbalize
 
     def body
       if all_keywords.empty?
-        "  __verbalized_send(:call)"
+        '  __verbalized_send(:call)'
       else
         "  __verbalized_send(:call, #{initialize_keywords_and_values})"
       end

--- a/lib/verbalize/error.rb
+++ b/lib/verbalize/error.rb
@@ -1,5 +1,3 @@
 module Verbalize
-  VerbalizeError = Class.new(StandardError)
-  # alias Verbalize::Error to Verbalize::VerbalizeError for now, for backwards compatibility
-  Error = Class.new(VerbalizeError)
+  Error = Class.new(StandardError)
 end

--- a/lib/verbalize/error.rb
+++ b/lib/verbalize/error.rb
@@ -1,3 +1,5 @@
 module Verbalize
   VerbalizeError = Class.new(StandardError)
+  # alias Verbalize::Error to Verbalize::VerbalizeError for now, for backwards compatibility
+  Error = Class.new(VerbalizeError)
 end

--- a/lib/verbalize/failure.rb
+++ b/lib/verbalize/failure.rb
@@ -14,9 +14,9 @@ module Verbalize
     end
 
     def value
-      raise Verbalize::Error, 'You called #value on a Failure result.  You should never use `Verbalize::Action#call` without also ' \
-        'explicitly handling potential errors.  Please use `Verbalize::Action#call!` to return a value directly on ' \
-        'successful execution of an action, or handle the error case explicitly if using `#call`.'
+      raise Verbalize::Error, 'You called #value on a Failure result.  You should never use `Verbalize::Action#call` ' \
+        'without also explicitly handling potential errors.  Please use `Verbalize::Action#call!` to return a value ' \
+        'directly on successful execution of an action, or handle the error case explicitly if using `#call`.'
     end
   end
 end

--- a/lib/verbalize/failure.rb
+++ b/lib/verbalize/failure.rb
@@ -1,4 +1,5 @@
 require_relative 'result'
+require_relative 'error'
 
 module Verbalize
   class Failure < Result
@@ -13,10 +14,9 @@ module Verbalize
     end
 
     def value
-      warn Kernel.caller.first + ': `Verbalize::Failure#value` is deprecated; use `Verbalize::Failure#failure` '\
-        'instead when explicitly handling failures. `Verbalize::Failure#value` will raise an exception in Verbalize '\
-        '2.0 to prevent accidental use of `#value` on failure results without explicit error handling. '
-      @value
+      raise Verbalize::Error, 'You called #value on a Failure result.  You should never use `Verbalize::Action#call` without also ' \
+        'explicitly handling potential errors.  Please use `Verbalize::Action#call!` to return a value directly on ' \
+        'successful execution of an action, or handle the error case explicitly if using `#call`.'
     end
   end
 end

--- a/lib/verbalize/result.rb
+++ b/lib/verbalize/result.rb
@@ -22,9 +22,7 @@ module Verbalize
     end
 
     def value
-      warn Kernel.caller.first + ': `Verbalize::Result#value` is deprecated and will be removed in Verbalize 2.0. '\
-        'Use `Verbalize::Failure#error` or `Verbalize::Success#value` instead.'
-      @value
+      raise NotImplementedError, 'Subclasses must override Verbalize::Result#value'
     end
   end
 end

--- a/spec/build_dangerous_action_method_spec.rb
+++ b/spec/build_dangerous_action_method_spec.rb
@@ -12,16 +12,6 @@ end
       METHOD
     end
 
-    it 'builds a method string with no keywords and a given method name' do
-      result = described_class.call(method_name: :some_action)
-
-      expect(result).to eql(<<-METHOD)
-def self.some_action!()
-  __verbalized_send!(:some_action)
-end
-      METHOD
-    end
-
     it 'builds a method string with one required keyword' do
       result = described_class.call(required_keywords: [:some_required_keyword])
 

--- a/spec/build_dangerous_action_method_spec.rb
+++ b/spec/build_dangerous_action_method_spec.rb
@@ -7,7 +7,7 @@ describe Verbalize::BuildDangerousActionMethod do
 
       expect(result).to eql(<<-METHOD)
 def self.call!()
-  __verbalized_send!(:call)
+  __verbalized_send!
 end
       METHOD
     end
@@ -17,7 +17,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call!(some_required_keyword:)
-  __verbalized_send!(:call, some_required_keyword: some_required_keyword)
+  __verbalized_send!(some_required_keyword: some_required_keyword)
 end
       METHOD
     end
@@ -27,7 +27,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call!(some_optional_keyword: nil)
-  __verbalized_send!(:call, some_optional_keyword: some_optional_keyword)
+  __verbalized_send!(some_optional_keyword: some_optional_keyword)
 end
       METHOD
     end
@@ -39,7 +39,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call!(some_required_keyword_1:, some_required_keyword_2:)
-  __verbalized_send!(:call, some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2)
+  __verbalized_send!(some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2)
 end
       METHOD
     end
@@ -51,7 +51,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call!(some_optional_keyword_1: nil, some_optional_keyword_2: nil)
-  __verbalized_send!(:call, some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2)
+  __verbalized_send!(some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2)
 end
       METHOD
     end
@@ -64,7 +64,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call!(some_required_keyword_1:, some_required_keyword_2:, some_optional_keyword_1: nil, some_optional_keyword_2: nil)
-  __verbalized_send!(:call, some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2, some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2)
+  __verbalized_send!(some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2, some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2)
 end
       METHOD
     end

--- a/spec/build_method_base_spec.rb
+++ b/spec/build_method_base_spec.rb
@@ -1,0 +1,47 @@
+require 'verbalize/build_method_base'
+
+describe Verbalize::BuildMethodBase do
+  describe '.call' do
+    let(:test_class) do
+      Class.new(described_class)
+    end
+
+    it 'raises NotImplementedError when the subclass does not implement #declaration' do
+      test_class = Class.new(described_class) do
+        def body
+          'the body'
+        end
+      end
+
+      expect do
+        test_class.call
+      end.to raise_error NotImplementedError
+    end
+
+    it 'raises NotImplementedError when the subclass does not implement #body' do
+      test_class = Class.new(described_class) do
+        def declaration
+          'def foo'
+        end
+      end
+
+      expect do
+        test_class.call
+      end.to raise_error NotImplementedError
+    end
+
+    it 'joins the parts together' do
+      test_class = Class.new(described_class) do
+        def declaration
+          'def foo'
+        end
+
+        def body
+          'the body'
+        end
+      end
+
+      expect(test_class.call).to eq "def foo\nthe body\nend\n"
+    end
+  end
+end

--- a/spec/build_safe_action_method_spec.rb
+++ b/spec/build_safe_action_method_spec.rb
@@ -12,16 +12,6 @@ end
       METHOD
     end
 
-    it 'builds a method string with no keywords and a given method name' do
-      result = described_class.call(method_name: :some_action)
-
-      expect(result).to eql(<<-METHOD)
-def self.some_action()
-  __verbalized_send(:some_action)
-end
-      METHOD
-    end
-
     it 'builds a method string with one required keyword' do
       result = described_class.call(required_keywords: [:some_lonely_required_keyword])
 

--- a/spec/build_safe_action_method_spec.rb
+++ b/spec/build_safe_action_method_spec.rb
@@ -7,7 +7,7 @@ describe Verbalize::BuildSafeActionMethod do
 
       expect(result).to eql(<<-METHOD)
 def self.call()
-  __verbalized_send(:call)
+  __verbalized_send
 end
       METHOD
     end
@@ -17,7 +17,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call(some_lonely_required_keyword:)
-  __verbalized_send(:call, some_lonely_required_keyword: some_lonely_required_keyword)
+  __verbalized_send(some_lonely_required_keyword: some_lonely_required_keyword)
 end
       METHOD
     end
@@ -27,7 +27,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call(some_lonely_optional_keyword: nil)
-  __verbalized_send(:call, some_lonely_optional_keyword: some_lonely_optional_keyword)
+  __verbalized_send(some_lonely_optional_keyword: some_lonely_optional_keyword)
 end
       METHOD
     end
@@ -39,7 +39,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call(some_required_keyword_1:, some_required_keyword_2:)
-  __verbalized_send(:call, some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2)
+  __verbalized_send(some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2)
 end
       METHOD
     end
@@ -51,7 +51,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call(some_optional_keyword_1: nil, some_optional_keyword_2: nil)
-  __verbalized_send(:call, some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2)
+  __verbalized_send(some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2)
 end
       METHOD
     end
@@ -64,7 +64,7 @@ end
 
       expect(result).to eql(<<-METHOD)
 def self.call(some_required_keyword_1:, some_required_keyword_2:, some_optional_keyword_1: nil, some_optional_keyword_2: nil)
-  __verbalized_send(:call, some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2, some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2)
+  __verbalized_send(some_required_keyword_1: some_required_keyword_1, some_required_keyword_2: some_required_keyword_2, some_optional_keyword_1: some_optional_keyword_1, some_optional_keyword_2: some_optional_keyword_2)
 end
       METHOD
     end

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -51,19 +51,11 @@ describe Verbalize::Failure do
   end
 
   describe '#value' do
-    it 'is the error message' do
-      result = described_class.new('some_error')
-
-      expect(result.failure).to eq 'some_error'
-    end
-
-    it 'emits a deprecation warning' do
-      expected_message = Regexp.compile('.*failure_spec.rb:\\d+:in .*: `Verbalize::Failure#value` is deprecated; ' \
-                                          'use `Verbalize::Failure#failure` instead')
+    it 'raises an exception' do
       result = described_class.new('some_error')
       expect do
         result.value
-      end.to output(expected_message).to_stderr
+      end.to raise_error(StandardError, /You called #value on a Failure result/)
     end
   end
 

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -1,31 +1,150 @@
 require 'verbalize/action'
 
 describe Verbalize::Action do
-  describe '.verbalize' do
-    it 'returns a Verbalize::Failure instance on fail!' do
-      some_class = Class.new do
-        include Verbalize::Action
+  let(:a) { double(divide_by: 20) }
 
-        def call
-          fail!('Some error')
-        end
+  let(:simple_action) do
+    Class.new do
+      include Verbalize::Action
+
+      input :a, :b, :should_fail
+
+      def call
+        fail! 'Are you crazy?!? You can’t divide by zero!' if should_fail
+        a.divide_by(b)
       end
+    end
+  end
 
-      expect(some_class.call).to be_an_instance_of(Verbalize::Failure)
+  describe '.call' do
+    it 'returns a Verbalize::Failure instance on fail!' do
+      result = simple_action.call(a: a, b: 10, should_fail: true)
+
+      expect(result).to be_an_instance_of(Verbalize::Failure)
+      expect(result).to be_failure
+      expect(result.failure).to eq 'Are you crazy?!? You can’t divide by zero!'
     end
 
     it 'returns a Verbalize::Success instance on success' do
+      result = simple_action.call(a: a, b: 10, should_fail: false)
+
+      expect(result).to be_an_instance_of(Verbalize::Success)
+      expect(result).to be_success
+      expect(result.value).to eq 20
+    end
+
+    it 'short circuits the call block on failure' do
+      simple_action.call(a: a, b: 10, should_fail: true)
+
+      expect(a).not_to have_received(:divide_by)
+    end
+
+    it 'stubbed failures return a Verbalize::Falure on `call`' do
+      allow(simple_action).to receive(:perform).and_throw(described_class::THROWN_SYMBOL, 'foo error')
+
+      result = simple_action.call(a: a, b: 10, should_fail: false)
+
+      expect(result).not_to   be_success
+      expect(result).to       be_failed
+      expect(result.failure).to eq 'foo error'
+    end
+
+    it 'fails up multiple levels' do
+      some_inner_inner_class = Class.new do
+        include Verbalize::Action
+
+        def call
+          fail! :some_failure_message
+        end
+      end
+
+      some_inner_class = Class.new do
+        include Verbalize::Action
+      end
+
+      some_inner_class.class_exec(some_inner_inner_class) do |interactor_class|
+        define_method(:call) do
+          interactor_class.call!
+        end
+      end
+
+      some_outer_class = Class.new do
+        include Verbalize::Action
+      end
+
+      some_outer_class.class_exec(some_inner_class) do |interactor_class|
+        define_method(:call) do
+          interactor_class.call!
+        end
+      end
+
+      outcome, value = some_outer_class.call
+
+      expect(outcome).to eq :error
+      expect(value).to   eq :some_failure_message
+    end
+  end
+
+  describe '.call!' do
+    it 'fails up to a parent action' do
+      some_inner_class = Class.new do
+        include Verbalize::Action
+
+        def call
+          fail! :some_failure_message
+        end
+      end
+
+      some_outer_class = Class.new do
+        include Verbalize::Action
+      end
+
+      some_outer_class.class_exec(some_inner_class) do |interactor_class|
+        define_method(:call) do
+          interactor_class.call!
+        end
+      end
+
+      result = some_outer_class.call
+
+      expect(result).not_to   be_success
+      expect(result).to       be_failed
+      expect(result.failure).to eq :some_failure_message
+    end
+
+    it 'stubbed failures raise a Verbalize::Error when using `call!`' do
+      some_action = Class.new do
+        include Verbalize::Action
+
+        def call
+          fail! :some_failure_message
+        end
+      end
+
+      allow(some_action).to receive(:perform).and_throw(described_class::THROWN_SYMBOL, 'foo error')
+
+      expect do
+        some_action.call!
+      end.to raise_error(Verbalize::Error, 'Unhandled fail! called with: "foo error".')
+    end
+
+    it 'raises an error with a helpful message \
+    if an action fails without being handled' do
       some_class = Class.new do
         include Verbalize::Action
 
         def call
-          true
+          fail! :some_failure_message
         end
       end
 
-      expect(some_class.call).to be_an_instance_of(Verbalize::Success)
+      expect do
+        some_class.call!
+      end.to raise_error(Verbalize::Error, 'Unhandled fail! called with: :some_failure_message.')
     end
+  end
 
+  describe '.input' do
     context 'with arguments' do
       it 'allows arguments to be defined and delegates the class method \
       to the instance method' do
@@ -114,22 +233,6 @@ describe Verbalize::Action do
         expect(result.value).to eql(:some_behavior)
       end
 
-      it 'allows you to fail an action and not execute remaining lines' do
-        some_class = Class.new do
-          include Verbalize::Action
-
-          def call
-            fail! 'Are you crazy?!? You can’t divide by zero!'
-            1 / 0
-          end
-        end
-
-        result = some_class.call
-
-        expect(result).to be_failed
-        expect(result.failure).to eql('Are you crazy?!? You can’t divide by zero!')
-      end
-
       it 'raises an error if you specify unrecognized keyword/value arguments' do
         expect do
           Class.new do
@@ -139,162 +242,6 @@ describe Verbalize::Action do
           end
         end.to raise_error(ArgumentError)
       end
-    end
-
-    it 'fails up to a parent action' do
-      some_inner_class = Class.new do
-        include Verbalize::Action
-
-        def call
-          fail! :some_failure_message
-        end
-      end
-
-      some_outer_class = Class.new do
-        include Verbalize::Action
-      end
-
-      some_outer_class.class_exec(some_inner_class) do |interactor_class|
-        define_method(:call) do
-          interactor_class.call!
-        end
-      end
-
-      result = some_outer_class.call
-
-      expect(result).not_to   be_success
-      expect(result).to       be_failed
-      expect(result.failure).to eq :some_failure_message
-    end
-
-    it 'stubbed failures return a Verbalize::Falure on `call`' do
-      some_action = Class.new do
-        include Verbalize::Action
-
-        def call
-          fail! :some_failure_message
-        end
-      end
-
-      allow(some_action).to receive(:perform).and_throw(described_class::THROWN_SYMBOL, 'foo error')
-
-      result = some_action.call
-
-      expect(result).not_to   be_success
-      expect(result).to       be_failed
-      expect(result.failure).to eq 'foo error'
-    end
-
-    it 'stubbed failures raise a Verbalize::Error when using `call!`' do
-      some_action = Class.new do
-        include Verbalize::Action
-
-        def call
-          fail! :some_failure_message
-        end
-      end
-
-      allow(some_action).to receive(:perform).and_throw(described_class::THROWN_SYMBOL, 'foo error')
-
-      expect do
-        some_action.call!
-      end.to raise_error(Verbalize::Error, 'Unhandled fail! called with: "foo error".')
-    end
-
-    it 'fails up multiple levels' do
-      some_inner_inner_class = Class.new do
-        include Verbalize::Action
-
-        def call
-          fail! :some_failure_message
-        end
-      end
-
-      some_inner_class = Class.new do
-        include Verbalize::Action
-      end
-
-      some_inner_class.class_exec(some_inner_inner_class) do |interactor_class|
-        define_method(:call) do
-          interactor_class.call!
-        end
-      end
-
-      some_outer_class = Class.new do
-        include Verbalize::Action
-      end
-
-      some_outer_class.class_exec(some_inner_class) do |interactor_class|
-        define_method(:call) do
-          interactor_class.call!
-        end
-      end
-
-      outcome, value = some_outer_class.call
-
-      expect(outcome).to eq :error
-      expect(value).to   eq :some_failure_message
-    end
-
-    it 'raises an error with a helpful message \
-    if an action fails without being handled' do
-      some_class = Class.new do
-        include Verbalize::Action
-
-        def call
-          fail! :some_failure_message
-        end
-      end
-
-      expect { some_class.call! }.to raise_error(
-        Verbalize::Error, 'Unhandled fail! called with: :some_failure_message.'
-      )
-    end
-
-    it 'raises an error with a helpful message if an action with keywords \
-    fails without being handled' do
-      some_class = Class.new do
-        include Verbalize::Action
-
-        input :a, :b
-
-        def call
-          fail! :some_failure_message if b.zero?
-        end
-      end
-
-      expect { some_class.call!(a: 1, b: 0) }.to raise_error(
-        Verbalize::Error, 'Unhandled fail! called with: :some_failure_message.'
-      )
-    end
-
-    it 'fails up to a parent action with keywords' do
-      some_inner_class = Class.new do
-        include Verbalize::Action
-
-        input :a, :b
-
-        def call
-          fail! :some_failure_message if b.zero?
-        end
-      end
-
-      some_outer_class = Class.new do
-        include Verbalize::Action
-      end
-
-      some_outer_class.class_exec(some_inner_class) do |interactor_class|
-        input :a, :b
-
-        define_method(:call) do
-          interactor_class.call!(a: a, b: b)
-        end
-      end
-
-      outcome, value = some_outer_class.call(a: 1, b: 0)
-
-      expect(outcome).to eq :error
-      expect(value).to   eq :some_failure_message
     end
   end
 end

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -241,7 +241,7 @@ describe Verbalize::Action do
       end
 
       expect { some_class.call! }.to raise_error(
-        Verbalize::VerbalizeError, 'Unhandled fail! called with: :some_failure_message.'
+        Verbalize::Error, 'Unhandled fail! called with: :some_failure_message.'
       )
     end
 
@@ -258,7 +258,7 @@ describe Verbalize::Action do
       end
 
       expect { some_class.call!(a: 1, b: 0) }.to raise_error(
-        Verbalize::VerbalizeError, 'Unhandled fail! called with: :some_failure_message.'
+        Verbalize::Error, 'Unhandled fail! called with: :some_failure_message.'
       )
     end
 

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -125,10 +125,6 @@ describe Verbalize::Action do
     it 'stubbed failures raise a Verbalize::Error when using `call!`' do
       some_action = Class.new do
         include Verbalize::Action
-
-        def call
-          fail! :some_failure_message
-        end
       end
 
       allow(some_action).to receive(:perform).and_throw(described_class::THROWN_SYMBOL, 'foo error')

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -45,35 +45,6 @@ describe Verbalize::Action do
         expect(result.value).to eql(42)
       end
 
-      it 'allows class & instance method to be named differently' do
-        some_class = Class.new do
-          include Verbalize::Action
-
-          verbalize :some_method_name
-
-          def some_method_name
-            :some_method_result
-          end
-        end
-
-        result = some_class.some_method_name
-
-        expect(result).to be_success
-        expect(result.value).to eql(:some_method_result)
-      end
-
-      it 'using custom method name emits a deprecation warning' do
-        expected_message = Regexp.compile('action_spec.rb:\d+.*use of custom method names for Actions is ' \
-                                          'deprecated.* define `#call` on your Action class instead')
-        expect do
-          Class.new do
-            include Verbalize::Action
-
-            verbalize :some_method_name
-          end
-        end.to output(expected_message).to_stderr
-      end
-
       it 'raises an error when you don’t specify a required argument' do
         some_class = Class.new do
           include Verbalize::Action

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -66,20 +66,11 @@ describe Verbalize::Result do
   end
 
   describe '#value' do
-    it 'is simply the value' do
-      result = described_class.new(outcome: nil, value: :some_value)
-
-      expect(result.value).to eql(:some_value)
-    end
-
-    it 'emits a deprecation warning' do
-      expected_message = Regexp.compile('.*result_spec.rb:\\d+:in .*: `Verbalize::Result#value` is deprecated ' \
-                                          'and will be removed in Verbalize 2\\.0\\. Use `Verbalize::Failure#error` ' \
-                                          'or `Verbalize::Success#value` instead\\.')
+    it 'raises a NotImplementedError when not overridden' do
       result = described_class.new(outcome: nil, value: :some_value)
       expect do
         result.value
-      end.to output(expected_message).to_stderr
+      end.to raise_error(NotImplementedError, 'Subclasses must override Verbalize::Result#value')
     end
   end
 


### PR DESCRIPTION
@taylorzr Per our previous discussion, this makes the changes we discussed for v2.0:

- Raise an appropriate error when calling `Failure#value`
- Create `Action#perform` method for easier/consistent stubbing in tests.
- Remove support for alternate method names and related `verbalize` DSL method
- Update documentation appropriately