### PR TITLE
Add inputs tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ class Add
   end
 end
 
-Add.inputs # [:a, :b]
+Add.required_inputs # [:a, :b]
 Add.optional_inputs # [:c, :d]
+Add.inputs # [:a, :b, :c, :d]
 ```
 
 ## Comparison/Benchmark

--- a/README.md
+++ b/README.md
@@ -69,6 +69,32 @@ result = Divide.call(a: 1, b: 0) # => [:error, 'You can’t divide by 0']
 result.failed? # => true
 ```
 
+### Reflection
+```ruby
+class Add
+  include Verbalize::Action
+
+  input :a, :b, optional: [:c, :d]
+
+  def call
+    a + b + c + d
+  end
+
+  private
+
+  def c
+    @c ||= 0
+  end
+
+  def d
+    @d ||= 0
+  end
+end
+
+Add.inputs # [:a, :b]
+Add.optional_inputs # [:c, :d]
+```
+
 ## Comparison/Benchmark
 ```ruby
 require 'verbalize'
@@ -155,15 +181,15 @@ Comparison:
 ### Happy Path
 
 When testing positive cases of a `Verbalize::Action`, it is recommended to test using the `call!` class method and
-assert on the result.  This implicitly ensures a successful result, and your tests will fail with a bang! if 
+assert on the result.  This implicitly ensures a successful result, and your tests will fail with a bang! if
 something goes wrong:
 
 ```ruby
 class MyAction
   include Verbalize::Action
-  
+
   input :a
-  
+
   def call
     fail!('#{a} is greater than than 100!') if a >= 100
     a + 1
@@ -178,28 +204,28 @@ end
 
 ### Sad Path
 
-When testing negative cases of a `Verbalize::Action`, it is recommended to test using the `call` non-bang 
+When testing negative cases of a `Verbalize::Action`, it is recommended to test using the `call` non-bang
 class method which will return a `Verbalize::Failure` on failure.
 
-Use of `call!` here is not advised as it will result in an exception being thrown. Set assertions on both 
+Use of `call!` here is not advised as it will result in an exception being thrown. Set assertions on both
 the failure outcome and value:
 
 ```ruby
 class MyAction
   include Verbalize::Action
-  
+
   input :a
-  
+
   def call
     fail!('#{a} is greater than 100!') if a >= 100
     a + 1
   end
 end
-  
+
 # rspec:
 it 'fails when the input is out of bounds' do
   result = MyAction.call(a: 1000)
-  
+
   expect(result).to be_failed
   expect(result.failure).to eq '1000 is greater than 100!'
 end
@@ -208,11 +234,11 @@ end
 ### Stubbing Responses
 
 When unit testing, it may be necessary to stub the responses of Verbalize actions.  To correctly stub responses,
-you should __always__ stub the `MyAction.perform` class method on the action class being stubbed per the 
+you should __always__ stub the `MyAction.perform` class method on the action class being stubbed per the
 instructions below.  __Never__ stub the `call` or `call!` methods directly.
 
 Stubbing `.perform` will enable `Verbalize` to wrap results correctly for references to either `call` or `call!`.
- 
+
 #### Stubbing Successful Responses
 
 To simulate a successful response of the `Verbalize::Action` being stubbed, you should stub the `MyAction.perform`
@@ -225,7 +251,7 @@ class Foo
   def self.multiply_by(multiple)
     result = MyAction.call(a: 1)
     raise "I couldn't do the thing!" if result.failure?
-    
+
     result.value * multiple
   end
 end
@@ -238,9 +264,9 @@ describe Foo do
       allow(MyAction).to receive(:perform)
         .with(a: 1)
         .and_return(123)
-      
+
       result = described_class.multiply_by(100)
-      
+
       expect(result).to eq 12300
     end
   end
@@ -266,7 +292,7 @@ describe Foo do
       allow(MyAction).to receive(:perform)
         .with(a: 1)
         .and_throw(::Verbalize::THROWN_SYMBOL, 'Y U NO!')
-      
+
       expect {
         described_class.multiply_by(100)
       }.to raise_error "I couldn't do the thing!"
@@ -305,4 +331,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/taylor
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -25,6 +25,7 @@ module Verbalize
 
         class_eval Build.call(required_keywords, Array(optional))
       end
+      alias_method :inputs, :input
 
       def optional_inputs
         @optional_inputs || []

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -17,18 +17,22 @@ module Verbalize
 
     module ClassMethods
       def input(*required_keywords, optional: [])
-        @inputs = required_keywords
+        @required_inputs = required_keywords
         @optional_inputs = optional
 
         class_eval Build.call(required_keywords, Array(optional))
       end
 
-      def inputs
-        @inputs || []
+      def required_inputs
+        @required_inputs || []
       end
 
       def optional_inputs
         @optional_inputs || []
+      end
+
+      def inputs
+        required_inputs + optional_inputs
       end
 
       # Because call/call! are defined when Action.input is called, they would

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -17,15 +17,15 @@ module Verbalize
 
     module ClassMethods
       def input(*required_keywords, optional: [])
-        # treat `input` as an accessor if nothing is passed in.
-        return @inputs || [] if required_keywords.empty? && optional.empty?
-
         @inputs = required_keywords
         @optional_inputs = optional
 
         class_eval Build.call(required_keywords, Array(optional))
       end
-      alias_method :inputs, :input
+
+      def inputs
+        @inputs || []
+      end
 
       def optional_inputs
         @optional_inputs || []

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -17,7 +17,17 @@ module Verbalize
 
     module ClassMethods
       def input(*required_keywords, optional: [])
+        # treat `input` as an accessor if nothing is passed in.
+        return @inputs || [] if required_keywords.empty? && optional.empty?
+
+        @inputs = required_keywords
+        @optional_inputs = optional
+
         class_eval Build.call(required_keywords, Array(optional))
+      end
+
+      def optional_inputs
+        @optional_inputs || []
       end
 
       # Because call/call! are defined when Action.input is called, they would

--- a/lib/verbalize/version.rb
+++ b/lib/verbalize/version.rb
@@ -1,3 +1,3 @@
 module Verbalize
-  VERSION = '2.0.1'.freeze
+  VERSION = '2.0.2'.freeze
 end

--- a/lib/verbalize/version.rb
+++ b/lib/verbalize/version.rb
@@ -1,3 +1,3 @@
 module Verbalize
-  VERSION = '2.0.2'.freeze
+  VERSION = '2.0.1'.freeze
 end

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -190,26 +190,31 @@ describe Verbalize::Action do
 
   describe '.input' do
     context 'without_arguments' do
-      it 'delegates to the instance call method without arguments' do
-        some_class = Class.new do
+      let(:some_class) do
+        Class.new do
           include Verbalize::Action
 
           def call
             :some_behavior
           end
         end
+      end
 
+      it 'delegates to the instance call method without arguments' do
         result = some_class.call
 
         expect(result).to be_success
         expect(result.value).to eql(:some_behavior)
       end
+
+      it 'returns an empty array' do
+        expect(some_class.input).to eq []
+      end
     end
 
-    context 'with arguments' do
-      it 'allows arguments to be defined and delegates the class method \
-      to the instance method' do
-        some_class = Class.new do
+    context 'with required argumentsarguments' do
+      let(:some_class) do
+        Class.new do
           include Verbalize::Action
 
           input :a, :b
@@ -218,7 +223,10 @@ describe Verbalize::Action do
             a + b
           end
         end
+      end
 
+      it 'allows arguments to be defined and delegates the class method \
+      to the instance method' do
         result = some_class.call(a: 40, b: 2)
 
         expect(result).to be_success
@@ -226,19 +234,17 @@ describe Verbalize::Action do
       end
 
       it 'raises an error when you don’t specify a required argument' do
-        some_class = Class.new do
-          include Verbalize::Action
-
-          input :a, :b
-
-          def call; end
-        end
-
         expect { some_class.call(a: 42) }.to raise_error(ArgumentError)
       end
 
-      it 'allows you to specify an optional argument' do
-        some_class = Class.new do
+      it 'returns all required arguments' do
+        expect(some_class.input).to contain_exactly(:a, :b)
+      end
+    end
+
+    context 'with an optional argument' do
+      let(:some_class) do
+        Class.new do
           include Verbalize::Action
 
           input :a, optional: :b
@@ -251,22 +257,28 @@ describe Verbalize::Action do
             @b ||= 2
           end
         end
+      end
 
+      it 'allows you to specify an optional argument' do
         result = some_class.call(a: 40)
 
         expect(result).to be_success
         expect(result.value).to eql(42)
       end
 
-      it 'raises an error if you specify unrecognized keyword/value arguments' do
-        expect do
-          Class.new do
-            include Verbalize::Action
-
-            input improper: :usage
-          end
-        end.to raise_error(ArgumentError)
+      it 'only lists required inputs' do
+        expect(some_class.input).to contain_exactly(:a)
       end
+    end
+
+    it 'raises an error if you specify unrecognized keyword/value arguments' do
+      expect do
+        Class.new do
+          include Verbalize::Action
+
+          input improper: :usage
+        end
+      end.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -282,5 +282,43 @@ describe Verbalize::Action do
     end
   end
 
-  describe '.optional_inputs'
+  describe '.optional_inputs' do
+    context 'with no inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+        end
+      end
+
+      it 'returns an empty array' do
+        expect(some_class.optional_inputs).to eq []
+      end
+    end
+  end
+
+  context 'with no optional inputs' do
+    let(:some_class) do
+      Class.new do
+        include Verbalize::Action
+        input :a, :b
+      end
+    end
+
+    it 'returns an empty array' do
+      expect(some_class.optional_inputs).to eq []
+    end
+  end
+
+  context 'with optional inputs' do
+    let(:some_class) do
+      Class.new do
+        include Verbalize::Action
+        input :a, optional: [:b, :c]
+      end
+    end
+
+    it 'returns the optional inputs' do
+      expect(some_class.optional_inputs).to contain_exactly(:b, :c)
+    end
+  end
 end

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -208,7 +208,7 @@ describe Verbalize::Action do
       end
 
       it 'returns an empty array' do
-        expect(some_class.input).to eq []
+        expect(some_class.inputs).to eq []
       end
     end
 
@@ -238,7 +238,7 @@ describe Verbalize::Action do
       end
 
       it 'returns all required arguments' do
-        expect(some_class.input).to contain_exactly(:a, :b)
+        expect(some_class.inputs).to contain_exactly(:a, :b)
       end
     end
 
@@ -267,7 +267,7 @@ describe Verbalize::Action do
       end
 
       it 'only lists required inputs' do
-        expect(some_class.input).to contain_exactly(:a)
+        expect(some_class.inputs).to contain_exactly(:a)
       end
     end
 
@@ -281,4 +281,6 @@ describe Verbalize::Action do
       end.to raise_error(ArgumentError)
     end
   end
+
+  describe '.optional_inputs'
 end

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -212,7 +212,7 @@ describe Verbalize::Action do
       end
     end
 
-    context 'with required argumentsarguments' do
+    context 'with required arguments' do
       let(:some_class) do
         Class.new do
           include Verbalize::Action

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -188,7 +188,7 @@ describe Verbalize::Action do
     end
   end
 
-  describe '.input/.inputs' do
+  describe '.input' do
     context 'without_arguments' do
       let(:some_class) do
         Class.new do
@@ -205,10 +205,6 @@ describe Verbalize::Action do
 
         expect(result).to be_success
         expect(result.value).to eql(:some_behavior)
-      end
-
-      it '.inputs returns an empty array' do
-        expect(some_class.inputs).to eq []
       end
     end
 
@@ -236,10 +232,6 @@ describe Verbalize::Action do
       it 'raises an error when you don’t specify a required argument' do
         expect { some_class.call(a: 42) }.to raise_error(ArgumentError)
       end
-
-      it '.inputs returns all required inputs' do
-        expect(some_class.inputs).to contain_exactly(:a, :b)
-      end
     end
 
     context 'with an optional argument' do
@@ -265,10 +257,6 @@ describe Verbalize::Action do
         expect(result).to be_success
         expect(result.value).to eql(42)
       end
-
-      it '.inputs only returns required inputs' do
-        expect(some_class.inputs).to contain_exactly(:a)
-      end
     end
 
     it 'raises an error if you specify unrecognized keyword/value arguments' do
@@ -279,6 +267,46 @@ describe Verbalize::Action do
           input improper: :usage
         end
       end.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '.required_inputs' do
+    context 'with no inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+        end
+      end
+
+      it 'returns an empty array' do
+        expect(some_class.required_inputs).to eq []
+      end
+    end
+
+    context 'with no required inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+          input optional: [:a, :b]
+        end
+      end
+
+      it 'returns an empty array' do
+        expect(some_class.required_inputs).to eq []
+      end
+    end
+
+    context 'with required inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+          input :a, :b, optional: [:c, :d]
+        end
+      end
+
+      it 'returns the required inputs' do
+        expect(some_class.required_inputs).to contain_exactly(:a, :b)
+      end
     end
   end
 
@@ -294,31 +322,84 @@ describe Verbalize::Action do
         expect(some_class.optional_inputs).to eq []
       end
     end
-  end
 
-  context 'with no optional inputs' do
-    let(:some_class) do
-      Class.new do
-        include Verbalize::Action
-        input :a, :b
+    context 'with no optional inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+          input :a, :b
+        end
+      end
+
+      it 'returns an empty array' do
+        expect(some_class.optional_inputs).to eq []
       end
     end
 
-    it 'returns an empty array' do
-      expect(some_class.optional_inputs).to eq []
+    context 'with optional inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+          input :a, optional: [:b, :c]
+        end
+      end
+
+      it 'returns the optional inputs' do
+        expect(some_class.optional_inputs).to contain_exactly(:b, :c)
+      end
     end
   end
 
-  context 'with optional inputs' do
-    let(:some_class) do
-      Class.new do
-        include Verbalize::Action
-        input :a, optional: [:b, :c]
+  describe '.inputs' do
+    context 'with no inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+        end
+      end
+
+      it 'returns an empty array' do
+        expect(some_class.inputs).to eq []
       end
     end
 
-    it 'returns the optional inputs' do
-      expect(some_class.optional_inputs).to contain_exactly(:b, :c)
+    context 'with optional inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+          input optional: [:a, :b]
+        end
+      end
+
+      it 'returns an empty array' do
+        expect(some_class.inputs).to contain_exactly(:a, :b)
+      end
+    end
+
+    context 'with required inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+          input :a, :b
+        end
+      end
+
+      it 'returns an empty array' do
+        expect(some_class.inputs).to contain_exactly(:a, :b)
+      end
+    end
+
+    context 'with required and optional inputs' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+          input :a, :b, optional: [:c, :d]
+        end
+      end
+
+      it 'returns the required inputs' do
+        expect(some_class.inputs).to contain_exactly(:a, :b, :c, :d)
+      end
     end
   end
 end

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -188,7 +188,7 @@ describe Verbalize::Action do
     end
   end
 
-  describe '.input' do
+  describe '.input/.inputs' do
     context 'without_arguments' do
       let(:some_class) do
         Class.new do
@@ -207,7 +207,7 @@ describe Verbalize::Action do
         expect(result.value).to eql(:some_behavior)
       end
 
-      it 'returns an empty array' do
+      it '.inputs returns an empty array' do
         expect(some_class.inputs).to eq []
       end
     end
@@ -237,7 +237,7 @@ describe Verbalize::Action do
         expect { some_class.call(a: 42) }.to raise_error(ArgumentError)
       end
 
-      it 'returns all required arguments' do
+      it '.inputs returns all required inputs' do
         expect(some_class.inputs).to contain_exactly(:a, :b)
       end
     end
@@ -266,7 +266,7 @@ describe Verbalize::Action do
         expect(result.value).to eql(42)
       end
 
-      it 'only lists required inputs' do
+      it '.inputs only returns required inputs' do
         expect(some_class.inputs).to contain_exactly(:a)
       end
     end


### PR DESCRIPTION
1. Adds class-variable caching of the list of required inputs/and outputs.
2. updates `input` to return the list of required inputs when called without arguments, and aliases it to `inputs`
3. Adds `optional_inputs` method which returns the list of optional inputs.