### PR TITLE
Fix inputs with one optional

### DIFF
--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -18,9 +18,10 @@ module Verbalize
     module ClassMethods
       def input(*required_keywords, optional: [])
         @required_inputs = required_keywords
+        optional = Array(optional)
         @optional_inputs = optional
 
-        class_eval Build.call(required_keywords, Array(optional))
+        class_eval Build.call(required_keywords, optional)
       end
 
       def required_inputs

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -336,6 +336,19 @@ describe Verbalize::Action do
       end
     end
 
+    context 'with 1 optional input' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+          input :a, optional: :b
+        end
+      end
+
+      it 'returns the optional inputs' do
+        expect(some_class.optional_inputs).to contain_exactly(:b)
+      end
+    end
+
     context 'with optional inputs' do
       let(:some_class) do
         Class.new do
@@ -385,6 +398,19 @@ describe Verbalize::Action do
       end
 
       it 'returns an empty array' do
+        expect(some_class.inputs).to contain_exactly(:a, :b)
+      end
+    end
+
+    context 'with one required and one optional input' do
+      let(:some_class) do
+        Class.new do
+          include Verbalize::Action
+          input :a, optional: :b
+        end
+      end
+
+      it 'returns the required inputs' do
         expect(some_class.inputs).to contain_exactly(:a, :b)
       end
     end

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -410,7 +410,7 @@ describe Verbalize::Action do
         end
       end
 
-      it 'returns the required inputs' do
+      it 'returns the inputs' do
         expect(some_class.inputs).to contain_exactly(:a, :b)
       end
     end
@@ -423,7 +423,7 @@ describe Verbalize::Action do
         end
       end
 
-      it 'returns the required inputs' do
+      it 'returns the inputs' do
         expect(some_class.inputs).to contain_exactly(:a, :b, :c, :d)
       end
     end


### PR DESCRIPTION
@Kuraiou @tmertens 

```ruby
class Add
  input :a, optional: :b 
end
```

This is valid verbalize "syntax", but the instance variable @optional_inputs isn't arrayified when given only one symbol. So when the .inputs method was called, it tries `[:a] + :b` and errors.

This just makes sure the optional variable is always an array.