### PR TITLE
Add args to self.call to fix IDE complaints

### DIFF
--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -39,11 +39,11 @@ module Verbalize
       # Because call/call! are defined when Action.input is called, they would
       # not be defined when there is no input. So we pre-define them here, and
       # if there is any input, they are overwritten
-      def call
+      def call(*_args)
         __proxied_call
       end
 
-      def call!
+      def call!(*_args)
         __proxied_call!
       end
       alias_method :!, :call!


### PR DESCRIPTION
Rubymine throwing a fit about the number of args being passed to call. Thinks self.call doesn't have any args as it is declared.

![image](https://cloud.githubusercontent.com/assets/1912237/24424928/45cfe33a-13d0-11e7-89f2-2d5d2b7be727.png)
