### PR TITLE
Add #action_inputs

### DIFF
--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -11,6 +11,10 @@ module Verbalize
       throw(THROWN_SYMBOL, failure_value)
     end
 
+    def inputs
+      self.class.inputs.map { |i| [i, self.send(i)] }.to_h
+    end
+
     def self.included(target)
       target.extend ClassMethods
     end

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -11,7 +11,7 @@ module Verbalize
       throw(THROWN_SYMBOL, failure_value)
     end
 
-    def inputs
+    def action_inputs
       self.class.inputs.map { |i| [i, self.send(i)] }.to_h
     end
 

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -16,12 +16,12 @@ describe Verbalize::Action do
     end
   end
 
-  describe '#inputs' do
+  describe '#action_inputs' do
     let(:input_tester) do
       Class.new do
         include Verbalize::Action
         input :a, :b, optional: [:c, {d: 1, e: ->{ 2 }}]
-        def call; inputs; end
+        def call; action_inputs; end
       end
     end
 

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -16,6 +16,21 @@ describe Verbalize::Action do
     end
   end
 
+  describe '#inputs' do
+    let(:input_tester) do
+      Class.new do
+        include Verbalize::Action
+        input :a, :b, optional: [:c, {d: 1, e: ->{ 2 }}]
+        def call; inputs; end
+      end
+    end
+
+    it 'pulls all passed in values' do
+      results = input_tester.call!(a: :foo, b: :bar, d: 3)
+      expect(results).to eq({a: :foo, b: :bar, c: nil, d: 3, e: 2})
+    end
+  end
+
   describe '.call' do
     it 'returns a Verbalize::Failure instance on fail!' do
       result = simple_action.call(a: a, b: 0)


### PR DESCRIPTION
a method that returns the inputs and their values as a hash. this is used in a few places in avant-basic so it would be nice to have.