### PR TITLE
Update compatibility ruby 2 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## 2.3.1 - 2020-05-04
 ### Added
 - release documentation
+- ruby 2.7 compatibility to remove deprecation warnings
 
 ## 2.3.0 - 2019-09-23
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+ARG BUNDLER_VERSION=2.0.2
+ARG RUBY_VERSION=2.7.1
+ARG APP_ROOT=/gem
+
+#######################################
+###           Builder
+FROM ruby:${RUBY_VERSION}-alpine AS build-env
+
+ARG APP_ROOT
+
+ENV BUNDLE_APP_CONFIG="$APP_ROOT/.bundle"
+ARG PACKAGES="curl tzdata less git"
+RUN mkdir $APP_ROOT
+WORKDIR $APP_ROOT
+
+RUN apk update \
+    && apk upgrade \
+    && apk add --update --no-cache $PACKAGES
+
+#######################################
+###           Development
+FROM build-env AS development
+
+ARG BUNDLER_VERSION
+ARG APP_ROOT
+ENV BUNDLE_APP_CONFIG="$APP_ROOT/.bundle"
+
+WORKDIR $APP_ROOT
+
+RUN apk add --update --no-cache \
+  build-base \
+  git \
+  tzdata \
+  less
+
+RUN gem install bundler:$BUNDLER_VERSION
+
+COPY . $APP_ROOT
+
+RUN bundle install -j4 --retry 3 \
+  && rm -rf /usr/local/bundle/cache/*.gem \
+  && find /usr/local/bundle/gems/ -name "*.c" -delete \
+  && find /usr/local/bundle/gems/ -name "*.o" -delete
+
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   ruby:
-    version: '2.2'
+    version: '2.7'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.7'
+
+services:
+  ruby:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    command: bundle exec rspec
+    volumes:
+      - .:/gem
+

--- a/lib/verbalize/action.rb
+++ b/lib/verbalize/action.rb
@@ -106,8 +106,8 @@ module Verbalize
                     .to_h
       end
 
-      def perform(*args)
-        new(*args).send(:call)
+      def perform(**args)
+        new(**args).send(:call)
       end
 
       # We used __proxied_call/__proxied_call! for 2 reasons:
@@ -116,17 +116,17 @@ module Verbalize
       #      exist when stubbing
       #   2. Because #1, meta-programming a simple interface to these proxied
       #      methods is much simpler than meta-programming the full methods
-      def __proxied_call(*args)
+      def __proxied_call(**args)
         error = catch(:verbalize_error) do
-          value = perform(*args)
+          value = perform(**args)
           return Success.new(value)
         end
 
         Failure.new(error)
       end
 
-      def __proxied_call!(*args)
-        perform(*args)
+      def __proxied_call!(**args)
+        perform(**args)
       rescue UncaughtThrowError => uncaught_throw_error
         fail_value = uncaught_throw_error.value
         error = Verbalize::Error.new("Unhandled fail! called with: #{fail_value.inspect}.")

--- a/lib/verbalize/version.rb
+++ b/lib/verbalize/version.rb
@@ -1,3 +1,3 @@
 module Verbalize
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.3.1'.freeze
 end

--- a/spec/integration/action_spec.rb
+++ b/spec/integration/action_spec.rb
@@ -1,3 +1,4 @@
+require 'date'
 require 'verbalize/action'
 
 describe Verbalize::Action do


### PR DESCRIPTION
Ruby 2.7 introduced a large number of new deprecation warnings, including the following:

```
warn: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call ruby
```

Verbalize trips this in a few places, this PR solves the warning by replacing `*args` with `**args` in a few places. I've also added a docker-compose configuration in a second commit but happy to remove that if maintainers prefer not to include that at this time. If docker is welcome, I can complete the dockerization with updates to circle and README instructions.